### PR TITLE
Define new UnresolvedValueTypeFailure exception

### DIFF
--- a/compiler/compile/CompilationException.hpp
+++ b/compiler/compile/CompilationException.hpp
@@ -66,6 +66,16 @@ struct ILGenFailure : public virtual CompilationException
    };
 
 /**
+ * Unresolved value type class exception type.
+ *
+ * Thrown during IL Generation for unresolved value type class condition.
+ */
+struct UnresolvedValueTypeFailure : public virtual CompilationException
+   {
+   virtual const char* what() const throw() { return "Unresolved value type class in IL Generation"; }
+   };
+
+/**
  * Recoverable IL Generation Failure exception type.
  *
  * Thrown on an IL Generation Failure condition which the compiler can


### PR DESCRIPTION
Support is not yet ready in the JIT compiler for dealing with the class
of a value type that is unresolved.  For now the JIT compiler should
abort the compilation with an UnresolvedValueTypeFailure exception.

Signed-off-by:  Henry Zongaro <zongaro@ca.ibm.com>