### PR TITLE
Add acmpHelper and subsitutabilityComparison symbols

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.hpp
+++ b/compiler/compile/OMRSymbolReferenceTable.hpp
@@ -206,6 +206,16 @@ class SymbolReferenceTable
       startPCLinkageInfoSymbol,
       instanceShapeFromROMClassSymbol,
 
+      /** \brief Performs a substitutability comparison between two objects.
+       *
+       * The comparison takes as arguments references to the two objects.
+       *
+       * If the two objects are reference types, this is equivalen to a pointer compare.
+       * If the two objects are value types, then a structural comparison betweeen the two is performed.
+       * If the two objects are of different types, the exact behaviour depends on the language.
+       */
+      substitutabilityComparisonSymbol,
+
       /** \brief
        *
        *  This symbol is used by the code generator to recognize and inline a call which emulates the following

--- a/compiler/il/Aliases.cpp
+++ b/compiler/il/Aliases.cpp
@@ -138,6 +138,10 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
             {
             return &symRefTab->aliasBuilder.defaultMethodUseAliases();
             }
+         if (symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::substitutabilityComparisonSymbol))
+            {
+            return &symRefTab->aliasBuilder.defaultMethodUseAliases();
+            }
 
          if (!methodSymbol->isHelper())
             {
@@ -183,6 +187,7 @@ OMR::SymbolReference::getUseonlyAliasesBV(TR::SymbolReferenceTable * symRefTab)
             case TR_transactionExit:
             case TR_newObject:
             case TR_newObjectNoZeroInit:
+            case TR_acmpHelper:
             case TR_newValue:
             case TR_newValueNoZeroInit:
             case TR_newArray:
@@ -322,7 +327,8 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
          if (symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::arraySetSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::osrFearPointHelperSymbol) ||
              symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::potentialOSRPointHelperSymbol) ||
-             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::eaEscapeHelperSymbol))
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::eaEscapeHelperSymbol) ||
+             symRefTab->isNonHelper(self(), TR::SymbolReferenceTable::substitutabilityComparisonSymbol))
             {
             return &symRefTab->aliasBuilder.defaultMethodDefAliases();
             }
@@ -368,6 +374,7 @@ OMR::SymbolReference::getUseDefAliasesBV(bool isDirectCall, bool includeGCSafePo
             case TR_writeBarrierClassStoreRealTimeGC:
             case TR_writeBarrierStoreRealTimeGC:
             case TR_aNewArray:
+            case TR_acmpHelper:
             case TR_newValue:
             case TR_newValueNoZeroInit:
             case TR_newObject:

--- a/compiler/ras/Debug.cpp
+++ b/compiler/ras/Debug.cpp
@@ -2099,6 +2099,7 @@ static const char *commonNonhelperSymbolNames[] =
    "<j9methodConstantPoolField>",
    "<startPCLinkageInfo>",
    "<instanceShapeFromROMClass>",
+   "<substitutabilityComparison>",
    "<synchronizedFieldLoad>",
    "<atomicAdd>",
    "<atomicFetchAndAdd>",


### PR DESCRIPTION
The first of these is a VM helper the JIT will call when needed to do an acmp. The second is a non-helper that will be used as a high-level representation of an acmp operation that can work on both reference types and value types.